### PR TITLE
Updated setScriptName() function

### DIFF
--- a/src/GenericFunctions.php
+++ b/src/GenericFunctions.php
@@ -140,7 +140,7 @@ function setScriptName()
 {
     // Get the trace of who called this script and remove the ".php" suffix
     $backtrace = debug_backtrace();
-    define('SCRIPT_NAME', basename($backtrace[1]['file'], '.php'));
+    define('SCRIPT_NAME', basename(end($backtrace)['file'], '.php'));
 }
 
 /**


### PR DESCRIPTION
Since the porting of the generic functions was performed, the setScriptName() function was not working properly.

After testing the structure, I found that it was because the reference to the script caller was hardcoded to the 2nd element of the **_backtrace_** array.

I modified the setScriptName() function to now get the last element of the **_backtrace_** so that the script caller will still be referenced (after this is used in a package).

Example: a new project requires this repo using Composer, so the actual directory of **GenericFunctions.php** is _SERVER_ROOT/vendor/3bg-supply-co/php-functions/src/GenericFunctions.php_

Assume that a script in the project calls the function **_writeLog()_**, which requires the **SCRIPT_NAME** to be defined, is called. At this point, **SCRIPT_NAME** has not been defined, so **_writeLog_** calls the function **_setScriptName()_**.

In this example, calling the last element will ensure that the script that called **_writeLog()_** will be set as the **SCRIPT_NAME**, and not GenericFunctions (which would have been considered the script caller with the previous logic).