### PR TITLE
Updated setScriptName() to avoid redefining the SCRIPT_NAME

### DIFF
--- a/src/GenericFunctions.php
+++ b/src/GenericFunctions.php
@@ -138,9 +138,12 @@ function getToday($dateFormat = 'Y-m-d', $returnObject = false, $initialDateTime
  */
 function setScriptName()
 {
-    // Get the trace of who called this script and remove the ".php" suffix
-    $backtrace = debug_backtrace();
-    define('SCRIPT_NAME', basename(end($backtrace)['file'], '.php'));
+    // Check to see if the SCRIPT_NAME has already been defined or not
+    if(!defined('SCRIPT_NAME')) {
+      // Get the trace of who called this script and remove the ".php" suffix
+      $backtrace = debug_backtrace();
+      define('SCRIPT_NAME', basename(end($backtrace)['file'], '.php'));
+    }
 }
 
 /**
@@ -154,8 +157,8 @@ function setScriptName()
  */
 function writeLog($message, $logFile = null)
 {
-  // Set the SCRIPT_NAME, if needed
-  defined('SCRIPT_NAME') or setScriptName();
+  // Set the SCRIPT_NAME
+  setScriptName();
 
   // Set the variables for this function
   static $logFileName = null;


### PR DESCRIPTION
After running tests from the last release, there was a warning being thrown when 2 or more function calls were made to **_setScriptName()_**.

I added a check to see if the **SCRIPT_NAME** was already defined or not. If so, it would not try to define it.