### PR TITLE
Redefined location of credentials

### DIFF
--- a/src/GenericFunctions.php
+++ b/src/GenericFunctions.php
@@ -198,7 +198,7 @@ function writeLog($message, $logFile = null)
 function getCredentials($request)
 {
     // Set the variables for this function
-    $credentials = realpath(__DIR__ . '/../..') . '/credentials/credentials.ini';
+    $credentials = realpath(__DIR__ . '/../../../../../..') . '/credentials/credentials.ini';
 
     // Before anything, check to make sure there was a $request given
     if (!is_array($request) || empty($request)) {


### PR DESCRIPTION
As a temporary fix (until we come up with a uniform solution of WHERE and HOW to store credentials), the location of credentials will be in the same spot in the server.

However, since the **_getCredentials()_** changed subdirectories, so too did the location change for credentials.