### PR TITLE
Added checkProperty function

### DIFF
--- a/src/GenericFunctions.php
+++ b/src/GenericFunctions.php
@@ -233,3 +233,13 @@ function isValidJson(string $strJson) {
   json_decode($strJson);
   return (json_last_error() !== JSON_ERROR_NONE ? false : true);
 }
+
+/**
+ * This function is a shortcut to check if the object property has been set
+ * @param  stdClass $object   This is the object that is to be tested
+ * @param  string   $property This is the property that will be checked for in the $object
+ * @return boolean            This will return true if it exists, false if not.
+ */
+function checkProperty($object, $property) {
+  return isset($object->{$property});
+}


### PR DESCRIPTION
This commit reintroduces the previously referenced function called **_checkProperty_**, which is a shortcut to verify if an object has a property.

To use this function, simply do the following:
* Call the function with **2** parameters: **_checkProperty($firstParam, $secondParam)_**
* The **_$firstParam_** is the **object**
* The **_$secondParam_** is the **property**
* The function will retun **_true_** if the **property** exists, **_false_** otherwise